### PR TITLE
Vulnerability page fixes

### DIFF
--- a/frontend/src/components/confidentialAnnouncement/ConfidentialAdvisoryForm.js
+++ b/frontend/src/components/confidentialAnnouncement/ConfidentialAdvisoryForm.js
@@ -8,9 +8,9 @@ import { PRIVATE_CONTRACT_ABI } from '../../config';
 import { SUPPORTED_STORAGE_PRIVATE } from '../../storage/config';
 import Web3 from 'web3';
 
-import AES from '../../models/cryptography/AES';
-import RSA from '../../models/cryptography/RSA';
-import Utilities from '../../models/cryptography/Utilities';
+import AES from '../../cryptography/AES';
+import RSA from '../../cryptography/RSA';
+import Utilities from '../../cryptography/Utilities';
 import Web3Gateway from '../../models/web3/web3Gateway';
 
 import AcceptModal from '../announcement/AcceptModal';

--- a/frontend/src/components/vulnerabilities/AdvisoryLoadErrorModal.js
+++ b/frontend/src/components/vulnerabilities/AdvisoryLoadErrorModal.js
@@ -6,7 +6,7 @@ function AdvisoryLoadErrorModal({show, dismiss}) {
         <Modal size='lg' show={show} onHide={() => dismiss()}>
             <Modal.Header closeButton><Modal.Title>An error occurred!</Modal.Title></Modal.Header>
             <Modal.Body>
-                <p> An error occurred trying to read the selected security advisory, probably due to a encryption key mismatch. 
+                <p> An error occurred trying to read the selected security advisory, probably due to a encryption key mismatch or a hash mismatch. 
                     Update the public key on your contract and have your vendor re-announce the advisory. </p>
             </Modal.Body>
             <Modal.Footer>

--- a/frontend/src/components/vulnerabilities/VulnerabilityAccordion.js
+++ b/frontend/src/components/vulnerabilities/VulnerabilityAccordion.js
@@ -47,7 +47,8 @@ function VulnerabilityAccordion({ vulnerabilities, whitelist, dependencies, priv
                         advisory = await downloadAdvisory(vulnerability.cid, 
                             vulnerability.event.returnValues.decryptionKey, 
                             vulnerability.event.returnValues.iv,
-                            vulnerability.tx.to);
+                            vulnerability.tx.to,
+                            vulnerability.event.returnValues.hash);
                     }
                     catch (error) {
                         setShowError(true);
@@ -72,14 +73,14 @@ function VulnerabilityAccordion({ vulnerabilities, whitelist, dependencies, priv
      * @param {string} path to the advisory from announcement event. 
      * @returns SecurityAdvisory object parsed from the advisory.
      */
-    async function downloadAdvisory(path, decryptionKey = null, iv = null, address = null) {
+    async function downloadAdvisory(path, decryptionKey = null, iv = null, address = null, hash = null) {
         const storageSystem = path.split("/")[0];
         switch (storageSystem) {
             case "ipfs":
                 if (decryptionKey === null)
                     return await loadIpfsContent(path.split("/")[1]);
                 else 
-                    return await loadEncryptedIpfsContent(path.split("/")[1], decryptionKey, iv, address);
+                    return await loadEncryptedIpfsContent(path.split("/")[1], decryptionKey, iv, address, hash);
             case "arweave":
                 throw new Error("Arweave not yet supported.");
             case "swarm": 
@@ -88,7 +89,7 @@ function VulnerabilityAccordion({ vulnerabilities, whitelist, dependencies, priv
                 if (decryptionKey === null)
                     return await loadIpfsContent(path);
                 else 
-                    return await loadEncryptedIpfsContent(path, decryptionKey, iv, address);        
+                    return await loadEncryptedIpfsContent(path, decryptionKey, iv, address, hash);        
         }
     }
 
@@ -106,11 +107,22 @@ function VulnerabilityAccordion({ vulnerabilities, whitelist, dependencies, priv
     }
 
     /**
+     * Computes the hash of a content string and returns it as a HEX string.
+     * @param {string} content 
+     * @returns {string}
+     */
+    async function computeContentHash(content) {
+        const contentBytes = Utilities.stringToArrayBuffer(content);
+        const contentDigest = await window.crypto.subtle.digest("SHA-256", contentBytes);
+        return Web3.utils.bytesToHex(new Uint8Array(contentDigest));
+    }
+
+    /**
      * Download an encrypted advisory from IPFS.
      * @param {string} cid IPFS Content Identifier of the advisory.
      * @returns Parsed advisory.
      */
-    async function loadEncryptedIpfsContent(cid, decryptionKey, iv, vendor) {
+    async function loadEncryptedIpfsContent(cid, decryptionKey, iv, vendor, hash) {
         try {
             let privateKey = privateWhitelist.find(entry => entry.address === vendor).privateKey;
             let content = [];
@@ -123,6 +135,12 @@ function VulnerabilityAccordion({ vulnerabilities, whitelist, dependencies, priv
     
             const aes = new AES();
             const decryptedContent = await aes.decrypt(Buffer.from(content), key, new Uint8Array(Web3.utils.hexToBytes(iv)));
+            
+            const contentHash = computeContentHash(decryptedContent);
+
+            console.log(hash + "===" + contentHash);
+            if(hash !== contentHash) throw Error("Downloaded hash does not match computed hash")
+
             return new SecurityAdvisory(decryptedContent.toString('utf8'));
         }
         catch (error) {


### PR DESCRIPTION
- The SHA-256 hash included in confidential announcements is now verified against the downloaded and decrypted security advisory.
- Missing dependencies no longer crash the application.
- Missing whitelist or private contracts no longer crash the application.
- Either whitelist OR private contracts are needed for search as opposed to both.
- Private contracts now load without page refresh.